### PR TITLE
feat: TypeScript v6.0 対応のため tsconfig.json を修正

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,12 +23,10 @@
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "experimentalDecorators": true,
-    "ignoreDeprecations": "6.0",
-    "baseUrl": ".",
     "newLine": "LF",
     "types": ["node", "jest"],
     "paths": {
-      "@/*": ["src/*"]
+      "@/*": ["./src/*"]
     }
   },
   "include": ["src/**/*"]


### PR DESCRIPTION
## 概要

TypeScript v6.0 への対応として、`tsconfig.json` から廃止予定の設定を削除し、根本的に修正します。

Fixes #1425

## 変更内容

- `ignoreDeprecations: "6.0"` を削除（TypeScript 7.0 で機能しなくなるため）
- `baseUrl: "."` を削除（`moduleResolution: "bundler"` 環境での廃止対応）
- `paths` の参照先を相対パス形式に更新
  - 変更前: `"@/*": ["src/*"]`
  - 変更後: `"@/*": ["./src/*"]`（tsconfig.json 基準の相対パス）

## 確認事項

- [x] `pnpm lint:tsc` でビルドが通ることを確認
- [x] `pnpm lint` でリントエラーがないことを確認
- [x] `pnpm test` でテストが通ることを確認
